### PR TITLE
Update to latest serde master

### DIFF
--- a/.travis.cargo_config
+++ b/.travis.cargo_config
@@ -1,0 +1,1 @@
+paths = [ "./deps/serde" ]

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,14 @@ sudo: false
 rust:
   # TODO feature flags. This is needed for tests right now.
   - nightly
+
+script:
+  - mkdir .cargo
+  - cp .travis.cargo_config .cargo/config
+  - mkdir deps
+  - |
+    git clone https://github.com/serde-rs/serde deps/serde
+    pushd deps/serde
+    git reset --hard origin/master
+    popd
+  - cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,11 +5,5 @@ authors = ["Joe Wilm <joe@jwilm.com>"]
 
 [dependencies]
 redis = "0.5"
-
-[dependencies.serde]
-git = "https://github.com/jwilm/serde"
-rev = "b0bc8e35946d5937f9af73804518a7ac8b5bf7ae"
-
-[dependencies.serde_macros]
-git = "https://github.com/jwilm/serde"
-rev = "b0bc8e35946d5937f9af73804518a7ac8b5bf7ae"
+serde = "0.6"
+serde_macros = "0.6"

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -286,7 +286,7 @@ impl serde::Deserializer for Deserializer {
     }
 
     #[inline]
-    fn deserialize_struct_key<V>(&mut self, mut visitor: V) -> Result<V::Value>
+    fn deserialize_struct_field<V>(&mut self, mut visitor: V) -> Result<V::Value>
         where V: serde::de::Visitor,
     {
         let s = try!(self.read_string());


### PR DESCRIPTION
The serde version in our Cargo.toml is now just 0.6. Although technically incorrect, this allows dependents to change serde revisions without having to update this project.

A .cargo/config was added for travis to support this feature.

All of this will be resolved once serde 0.7 is released.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/one-signal/redis-serde/3)
<!-- Reviewable:end -->
