### PR TITLE
Fix de newtype in pipeline hmap

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -344,6 +344,14 @@ impl serde::Deserializer for Deserializer {
         }
     }
 
+    #[inline]
+    fn deserialize_newtype_struct<V>(&mut self,
+                                     _name: &'static str,
+                                     mut visitor: V) -> Result<V::Value>
+        where V: serde::de::Visitor
+    {
+        visitor.visit_newtype_struct(self)
+    }
 }
 
 struct SeqVisitor<'a> {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -11,6 +11,7 @@ use serde::{self, de};
 #[derive(Debug)]
 pub enum Error {
     Syntax(String),
+    TypeMismatch(String),
     EndOfStream,
     UnknownField(String),
     MissingField(&'static str),
@@ -35,6 +36,7 @@ impl error::Error for Error {
     fn description(&self) -> &str {
         match *self {
             Error::Syntax(_) => "syntax error when decoding redis values",
+            Error::TypeMismatch(_) => "type mismatch when decoding redis values",
             Error::EndOfStream => "end of redis value stream",
             Error::UnknownField(_) => "unknown field",
             Error::MissingField(_) => "missing field",
@@ -60,6 +62,7 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Error::Syntax(ref reason) => write!(f, "SyntaxError({})", reason),
+            Error::TypeMismatch(ref t) => write!(f, "TypeMismatch(expected: {})", t),
             Error::EndOfStream => write!(f, "Reached end of stream"),
             Error::UnknownField(ref field) => write!(f, "got unexpected field: {}", field),
             Error::MissingField(ref field) => write!(f, "missing field: {}", field),
@@ -87,6 +90,10 @@ impl de::Error for Error {
 
     fn missing_field(field: &'static str) -> Error {
         Error::MissingField(field)
+    }
+
+    fn type_mismatch(t: ::serde::de::Type) -> Error {
+        Error::TypeMismatch(format!("{:?}", t))
     }
 }
 


### PR DESCRIPTION
Newtype structs were causing pipelined sequences to exit prematurely since they were also treated as a sequence. Now, deserializing a newtype struct uses the alternative visit method for newtype structs thereby avoiding treating it as a sequence.

Tests are failing due to change in recent nightly >.>

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/one-signal/redis-serde/4)
<!-- Reviewable:end -->
